### PR TITLE
Improve capybara plot legend

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -273,7 +273,7 @@ jobs:
           mkdir hepmc3-merged
           mv recon_ci_18x275_from_epic.eicrecon.edm4eic.root hepmc3-merged/
           mv recon_ci_18x275_from_edm4hep.eicrecon.edm4eic.root edm4hep-merged/
-          capybara bara -M EventHeader hepmc3-merged/recon_ci_18x275_from_epic.eicrecon.edm4eic.root edm4hep-merged/recon_ci_18x275_from_edm4hep.eicrecon.edm4eic.root
+          capybara bara -M EventHeader hepmc3-merged/*recon_ci_18x275_from_epic.eicrecon.edm4eic.root edm4hep-merged/recon_ci_18x275_from_edm4hep.eicrecon.edm4eic.root
           # Use PR number or commit SHA for unique directory name
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             REPORT_DIR="pr-${{ github.event.pull_request.number }}"

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -271,9 +271,9 @@ jobs:
           mkdir capybara-reports
           mkdir edm4hep-merged
           mkdir hepmc3-merged
-          mv recon_ci_18x275_from_epic.eicrecon.edm4eic.root hepmc3-merged/
-          mv recon_ci_18x275_from_edm4hep.eicrecon.edm4eic.root edm4hep-merged/
-          capybara bara -M EventHeader hepmc3-merged/*recon_ci_18x275_from_epic.eicrecon.edm4eic.root edm4hep-merged/recon_ci_18x275_from_edm4hep.eicrecon.edm4eic.root
+          mv recon_ci_18x275_from_epic.eicrecon.edm4eic.root hepmc3-merged/recon_ci_18x275.edm4eic.root
+          mv recon_ci_18x275_from_edm4hep.eicrecon.edm4eic.root edm4hep-merged/recon_ci_18x275.edm4eic.root
+          capybara bara -M EventHeader hepmc3-merged/*recon_ci_18x275.edm4eic.root edm4hep-merged/recon_ci_18x275.edm4eic.root
           # Use PR number or commit SHA for unique directory name
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             REPORT_DIR="pr-${{ github.event.pull_request.number }}"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The legend on the capybara plots is currently showing the full file path. This changes it to only show hepmc3-merged and edm4hep-merged.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
