### PR TITLE
Add hepmc3 weight propagation

### DIFF
--- a/configs/config.yml
+++ b/configs/config.yml
@@ -13,6 +13,7 @@ sources:
     mean_event_frequency: 0.1
     use_bunch_crossing: true
     generator_status_offset: 0
+    keep_weight: true
   - input_files:
       - input3.root
     name: background

--- a/configs/config_ci.yml
+++ b/configs/config_ci.yml
@@ -11,6 +11,7 @@ sources:
     static_events_per_timeframe: 1
     use_bunch_crossing: true
     generator_status_offset: 0
+    keep_weight: true
   - name: minbias
     static_number_of_events: false
     mean_event_frequency: 0.000083 # in GHz

--- a/configs/config_continue.yml
+++ b/configs/config_continue.yml
@@ -20,3 +20,4 @@ sources:
     static_events_per_timeframe: 1
     use_bunch_crossing: true
     generator_status_offset: 5000
+    keep_weight: true

--- a/configs/config_epic_10x275.yml
+++ b/configs/config_epic_10x275.yml
@@ -12,6 +12,7 @@ sources:
     static_events_per_timeframe: 1
     use_bunch_crossing: true
     generator_status_offset: 0
+    keep_weight: true
   - name: minbias
     input_files:
       - input3.edm4hep.root    

--- a/configs/config_epic_18x275.yml
+++ b/configs/config_epic_18x275.yml
@@ -12,6 +12,7 @@ sources:
     static_events_per_timeframe: 1
     use_bunch_crossing: true
     generator_status_offset: 0
+    keep_weight: true
   - name: minbias
     input_files:
       - input3.edm4hep.root    

--- a/configs/config_epic_5x100.yml
+++ b/configs/config_epic_5x100.yml
@@ -12,6 +12,7 @@ sources:
     static_events_per_timeframe: 1
     use_bunch_crossing: true
     generator_status_offset: 0
+    keep_weight: true
   - name: minbias
     input_files:
       - input3.edm4hep.root    

--- a/configs/config_hepmc3.yml
+++ b/configs/config_hepmc3.yml
@@ -16,12 +16,15 @@ sources:
     use_bunch_crossing: true
     attach_to_beam: false
     generator_status_offset: 0
+    keep_weight: true
     
   - input_files:
-      - input.hepmc3.tree.root
+      - input*.hepmc3.tree.root
     name: background
+    skip: 10000000
     static_number_of_events: true
     static_events_per_timeframe: 2
     use_bunch_crossing: true
     generator_status_offset: 1000
     already_merged: false
+    repeat_on_eof: true

--- a/include/HepMC3DataHandler.h
+++ b/include/HepMC3DataHandler.h
@@ -57,5 +57,6 @@ private:
     long insertHepMC3Event(const HepMC3::GenEvent& inevt,
                           std::unique_ptr<HepMC3::GenEvent>& hepframe,
                           double time,
-                          int baseStatus);
+                          int baseStatus,
+                          bool keepWeights);
 };

--- a/include/MergerConfig.h
+++ b/include/MergerConfig.h
@@ -26,6 +26,7 @@ struct SourceConfig {
 
     // New generator status offset
     int32_t  generator_status_offset{0};
+    bool     keep_weight{false};
 
     // Tree properties
     std::string tree_name{"events"};

--- a/src/CommandLineParser.cc
+++ b/src/CommandLineParser.cc
@@ -49,6 +49,8 @@ void CommandLineParser::printUsage(const char* program_name) {
               << "                              Beam spread for Gaussian smearing\n"
               << "  --source:NAME:status_offset OFFSET\n"
               << "                              Generator status offset\n"
+              << "  --source:NAME:keep_weight BOOL\n"
+              << "                              Keep event weights (true/false)\n"
               << "  --source:NAME:repeat_on_eof BOOL\n"
               << "                              Repeat source when EOF reached (true/false)\n"
               << "\nExamples:\n"
@@ -167,6 +169,8 @@ bool CommandLineParser::handleSourceOption(std::vector<SourceConfig>& sources, c
         source->beam_spread = std::stof(value);
     } else if (property == "status_offset") {
         source->generator_status_offset = std::stoi(value);
+    } else if (property == "keep_weight") {
+        source->keep_weight = parseBool(value);
     } else if (property == "already_merged") {
         source->already_merged = parseBool(value);
     } else if (property == "tree_name") {
@@ -214,6 +218,7 @@ void CommandLineParser::loadYAMLConfig(const std::string& config_file, MergerCon
             if (source_yaml["beam_speed"]) source.beam_speed = source_yaml["beam_speed"].as<float>();
             if (source_yaml["beam_spread"]) source.beam_spread = source_yaml["beam_spread"].as<float>();
             if (source_yaml["generator_status_offset"]) source.generator_status_offset = source_yaml["generator_status_offset"].as<int32_t>();
+            if (source_yaml["keep_weight"]) source.keep_weight = source_yaml["keep_weight"].as<bool>();
             if (source_yaml["repeat_on_eof"]) source.repeat_on_eof = source_yaml["repeat_on_eof"].as<bool>();
             config.sources.push_back(source);
         }
@@ -253,6 +258,12 @@ void CommandLineParser::mergeCliSources(MergerConfig& config, const std::vector<
                 }
                 if (cli_source.generator_status_offset != 0) {
                     existing_source.generator_status_offset = cli_source.generator_status_offset;
+                }
+                if (cli_source.keep_weight) {
+                    existing_source.keep_weight = cli_source.keep_weight;
+                }
+                if (cli_source.skip != 0) {
+                    existing_source.skip = cli_source.skip;
                 }
                 if (cli_source.already_merged) {
                     existing_source.already_merged = cli_source.already_merged;
@@ -315,6 +326,7 @@ void CommandLineParser::printConfiguration(const MergerConfig& config) {
         std::cout << "  Beam speed: " << source.beam_speed << " mm/ns" << std::endl;
         std::cout << "  Beam spread: " << source.beam_spread << std::endl;
         std::cout << "  Generator status offset: " << source.generator_status_offset << std::endl;
+        std::cout << "  Keep weight: " << (source.keep_weight ? "true" : "false") << std::endl;
         std::cout << "  Repeat on EOF: " << (source.repeat_on_eof ? "true" : "false") << std::endl;
     }
     std::cout << "Output file: " << config.output_file << std::endl;
@@ -378,6 +390,7 @@ MergerConfig CommandLineParser::parse(int argc, char* argv[]) {
         {"beam-speed", required_argument, 0, 1001},
         {"beam-spread", required_argument, 0, 1002},
         {"status-offset", required_argument, 0, 1003},
+        {"keep-weight", required_argument, 0, 1006},
         {"help", no_argument, 0, 'h'},
         {"version", no_argument, 0, 'v'},
         {0, 0, 0, 0}
@@ -426,6 +439,9 @@ MergerConfig CommandLineParser::parse(int argc, char* argv[]) {
                 break;
             case 1003:
                 default_source.generator_status_offset = std::stoi(optarg);
+                break;
+            case 1006:
+                default_source.keep_weight = parseBool(optarg);
                 break;
             case 1005:
                 config.random_seed = std::stoul(optarg);

--- a/src/HepMC3DataHandler.cc
+++ b/src/HepMC3DataHandler.cc
@@ -119,13 +119,14 @@ void HepMC3DataHandler::processEvent(DataSource& source) {
     const auto& event = hepmc3_source->getCurrentEvent();
     
     // Insert the event into the merged timeframe
-    insertHepMC3Event(event, current_timeframe_, time_offset_ns, config.generator_status_offset);
+    insertHepMC3Event(event, current_timeframe_, time_offset_ns, config.generator_status_offset, config.keep_weight);
 }
 
 long HepMC3DataHandler::insertHepMC3Event(const HepMC3::GenEvent& inevt,
                                             std::unique_ptr<HepMC3::GenEvent>& hepframe,
                                             double time,
-                                            int baseStatus) {
+                                            int baseStatus,
+                                            bool keepWeights) {
     // Convert time in nanoseconds to HepMC position units (mm)
     double timeHepmc = c_light * time;
     
@@ -181,6 +182,13 @@ long HepMC3DataHandler::insertHepMC3Event(const HepMC3::GenEvent& inevt,
     // Add all vertices to the merged event
     for (auto& vertex : vertices) {
         hepframe->add_vertex(vertex);
+    }
+
+    if(keepWeights) {
+        // Copy weights from the original event
+        for (const auto& weight : inevt.weights()) {
+            hepframe->weights().push_back(weight);
+        }
     }
     
     return finalParticleCount;


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Ensures that the weights are accessible from the hepmc3 files. At the moment only the final event in a timeframe will be stored based on which sources request their weights are stored but this is in line with the current hepmc3 merger

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #83 )
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
